### PR TITLE
記事の一覧・詳細取得機能の再実装

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -3,14 +3,36 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\StorePostRequest;
+use App\Services\IndexPostServiceInterface;
+use App\Services\ShowPostServiceInterface;
 use App\Services\StorePostServiceInterface;
 use Illuminate\Routing\Controller;
 
 class PostController extends Controller
 {
     public function __construct(
+        private IndexPostServiceInterface $index_post_service,
+        private ShowPostServiceInterface $show_post_service,
         private StorePostServiceInterface $store_post_service,
     ) {
+    }
+
+    public function index()
+    {
+        $posts = $this->index_post_service->execute();
+
+        return view('post.index', [
+            'posts' => $posts,
+        ]);
+    }
+
+    public function show(string $post_id)
+    {
+        $post = $this->show_post_service->execute($post_id);
+
+        return view('post.show', [
+            'post' => $post,
+        ]);
     }
 
     public function store(StorePostRequest $request)
@@ -23,6 +45,11 @@ class PostController extends Controller
             content: $form_data['content'],
         );
 
+        return redirect('/');
+    }
+
+    public function destroy()
+    {
         return redirect('/');
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -17,4 +17,12 @@ class Post extends Model
         'title',
         'content',
     ];
+
+    /**
+     * 投稿者の User を取得
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Services\IndexPostService;
+use App\Services\IndexPostServiceInterface;
+use App\Services\ShowPostService;
+use App\Services\ShowPostServiceInterface;
 use App\Services\StorePostService;
 use App\Services\StorePostServiceInterface;
 use App\Services\StoreSessionService;
@@ -19,6 +23,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->app->bind(IndexPostServiceInterface::class, IndexPostService::class);
+        $this->app->bind(ShowPostServiceInterface::class, ShowPostService::class);
         $this->app->bind(StorePostServiceInterface::class, StorePostService::class);
         $this->app->bind(StoreUserServiceInterface::class, StoreUserService::class);
         $this->app->bind(StoreSessionServiceInterface::class, StoreSessionService::class);

--- a/app/Services/IndexPostService.php
+++ b/app/Services/IndexPostService.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Post;
+use App\Services\IndexPostServiceInterface;
+
+class IndexPostService implements IndexPostServiceInterface
+{
+    public function execute()
+    {
+        return Post::with('user')->get()->sortByDesc('created_at');
+    }
+}

--- a/app/Services/IndexPostServiceInterface.php
+++ b/app/Services/IndexPostServiceInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Post;
+
+interface IndexPostServiceInterface
+{
+    /**
+     * @return Post[]
+     */
+    public function execute();
+}

--- a/app/Services/ShowPostService.php
+++ b/app/Services/ShowPostService.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Post;
+
+use App\Services\ShowPostServiceInterface;
+
+class ShowPostService implements ShowPostServiceInterface
+{
+    public function execute($id)
+    {
+        return Post::with('user')->get()->find($id);
+    }
+}

--- a/app/Services/ShowPostServiceInterface.php
+++ b/app/Services/ShowPostServiceInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Post;
+
+interface ShowPostServiceInterface
+{
+    /**
+     * @param string $id
+     * @return Post
+     */
+    public function execute($id);
+}

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -513,6 +513,12 @@ video {
   --tw-backdrop-saturate:  ;
   --tw-backdrop-sepia:  ;
 }
+.relative {
+  position: relative;
+}
+.col-span-1 {
+  grid-column: span 1 / span 1;
+}
 .mx-4 {
   margin-left: 1rem;
   margin-right: 1rem;
@@ -521,8 +527,18 @@ video {
   margin-left: auto;
   margin-right: auto;
 }
+.mx-8 {
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
 .mx-1 {
   margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+.mr-1 {
   margin-right: 0.25rem;
 }
 .mt-10 {
@@ -536,6 +552,18 @@ video {
 }
 .mb-6 {
   margin-bottom: 1.5rem;
+}
+.mb-20 {
+  margin-bottom: 5rem;
+}
+.mb-8 {
+  margin-bottom: 2rem;
+}
+.mb-1 {
+  margin-bottom: 0.25rem;
+}
+.mt-4 {
+  margin-top: 1rem;
 }
 .mb-10 {
   margin-bottom: 2.5rem;
@@ -552,11 +580,26 @@ video {
 .h-0 {
   height: 0px;
 }
+.h-6 {
+  height: 1.5rem;
+}
+.h-5 {
+  height: 1.25rem;
+}
 .h-auto {
   height: auto;
 }
-.h-6 {
-  height: 1.5rem;
+.h-10 {
+  height: 2.5rem;
+}
+.w-6 {
+  width: 1.5rem;
+}
+.w-64 {
+  width: 16rem;
+}
+.w-5 {
+  width: 1.25rem;
 }
 .w-full {
   width: 100%;
@@ -564,8 +607,8 @@ video {
 .w-16 {
   width: 4rem;
 }
-.w-6 {
-  width: 1.5rem;
+.w-10 {
+  width: 2.5rem;
 }
 .w-40 {
   width: 10rem;
@@ -576,6 +619,9 @@ video {
 .max-w-xl {
   max-width: 36rem;
 }
+.flex-grow {
+  flex-grow: 1;
+}
 .origin-top {
   transform-origin: top;
 }
@@ -585,6 +631,15 @@ video {
 }
 .flex-col {
   flex-direction: column;
+}
+.flex-wrap {
+  flex-wrap: wrap;
+}
+.items-start {
+  align-items: flex-start;
+}
+.items-end {
+  align-items: flex-end;
 }
 .items-center {
   align-items: center;
@@ -598,8 +653,14 @@ video {
 .justify-between {
   justify-content: space-between;
 }
+.justify-around {
+  justify-content: space-around;
+}
 .gap-8 {
   gap: 2rem;
+}
+.gap-4 {
+  gap: 1rem;
 }
 .overflow-hidden {
   overflow: hidden;
@@ -607,52 +668,69 @@ video {
 .rounded-lg {
   border-radius: 0.5rem;
 }
+.rounded-full {
+  border-radius: 9999px;
+}
 .border {
   border-width: 1px;
-}
-.border-gray-400 {
-  --tw-border-opacity: 1;
-  border-color: rgb(156 163 175 / var(--tw-border-opacity));
 }
 .border-teal-600 {
   --tw-border-opacity: 1;
   border-color: rgb(13 148 136 / var(--tw-border-opacity));
 }
+.border-gray-400 {
+  --tw-border-opacity: 1;
+  border-color: rgb(156 163 175 / var(--tw-border-opacity));
+}
 .bg-teal-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(13 148 136 / var(--tw-bg-opacity));
 }
-.p-2 {
-  padding: 0.5rem;
-}
 .p-6 {
   padding: 1.5rem;
 }
-.py-2 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+.p-4 {
+  padding: 1rem;
+}
+.p-2 {
+  padding: 0.5rem;
 }
 .px-4 {
   padding-left: 1rem;
   padding-right: 1rem;
 }
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
 .pl-2 {
   padding-left: 0.5rem;
 }
+.pb-10 {
+  padding-bottom: 2.5rem;
+}
 .text-center {
   text-align: center;
+}
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
 }
 .text-lg {
   font-size: 1.125rem;
   line-height: 1.75rem;
 }
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
 .text-sm {
   font-size: 0.875rem;
   line-height: 1.25rem;
 }
-.text-xl {
-  font-size: 1.25rem;
-  line-height: 1.75rem;
+.text-3xl {
+  font-size: 1.875rem;
+  line-height: 2.25rem;
 }
 .font-bold {
   font-weight: 700;
@@ -665,33 +743,37 @@ video {
   --tw-text-opacity: 1;
   color: rgb(13 148 136 / var(--tw-text-opacity));
 }
-.text-red-500 {
+.text-gray-600 {
   --tw-text-opacity: 1;
-  color: rgb(239 68 68 / var(--tw-text-opacity));
+  color: rgb(75 85 99 / var(--tw-text-opacity));
 }
 .text-teal-800 {
   --tw-text-opacity: 1;
   color: rgb(17 94 89 / var(--tw-text-opacity));
 }
-.shadow-lg {
-  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+.text-red-500 {
+  --tw-text-opacity: 1;
+  color: rgb(239 68 68 / var(--tw-text-opacity));
 }
 .shadow-md {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
-.transition-transform {
-  transition-property: transform;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
+.shadow-lg {
+  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 .transition-colors {
   transition-property: color, background-color, border-color, fill, stroke, -webkit-text-decoration-color;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, -webkit-text-decoration-color;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+.transition-transform {
+  transition-property: transform;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -702,6 +784,22 @@ video {
 .before\:right-8::before {
   content: var(--tw-content);
   right: 2rem;
+}
+.before\:-right-1\/2::before {
+  content: var(--tw-content);
+  right: -50%;
+}
+.before\:-top-12::before {
+  content: var(--tw-content);
+  top: -3rem;
+}
+.before\:-right-0\.5::before {
+  content: var(--tw-content);
+  right: -0.125rem;
+}
+.before\:-right-0::before {
+  content: var(--tw-content);
+  right: -0px;
 }
 .before\:hidden::before {
   content: var(--tw-content);
@@ -733,15 +831,15 @@ video {
   font-size: 0.875rem;
   line-height: 1.25rem;
 }
-.before\:text-red-500::before {
-  content: var(--tw-content);
-  --tw-text-opacity: 1;
-  color: rgb(239 68 68 / var(--tw-text-opacity));
-}
 .before\:text-white::before {
   content: var(--tw-content);
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+.before\:text-red-500::before {
+  content: var(--tw-content);
+  --tw-text-opacity: 1;
+  color: rgb(239 68 68 / var(--tw-text-opacity));
 }
 .before\:opacity-60::before {
   content: var(--tw-content);
@@ -753,12 +851,20 @@ video {
   --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
+.before\:content-\[\'\30ED\30B0\30A2\30A6\30C8\'\]::before {
+  --tw-content: 'ログアウト';
+  content: var(--tw-content);
+}
+.before\:content-\[\'\524A\9664\'\]::before {
+  --tw-content: '削除';
+  content: var(--tw-content);
+}
 .before\:content-\[\'\*\'\]::before {
   --tw-content: '*';
   content: var(--tw-content);
 }
-.before\:content-\[\'\30ED\30B0\30A2\30A6\30C8\'\]::before {
-  --tw-content: 'ログアウト';
+.before\:content-\[\'\7DE8\96C6\'\]::before {
+  --tw-content: '編集';
   content: var(--tw-content);
 }
 .hover\:bg-teal-500:hover {
@@ -772,6 +878,11 @@ video {
 .hover\:underline:hover {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
+}
+.hover\:shadow-md:hover {
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 .hover\:before\:inline-block:hover::before {
   content: var(--tw-content);

--- a/resources/views/partials/_layout.blade.php
+++ b/resources/views/partials/_layout.blade.php
@@ -6,7 +6,7 @@
 
     <title>KENSHU TIMES</title>
 
-    <link rel="stylesheet" href="css/app.css">
+    <link rel="stylesheet" href="/css/app.css">
     <style>
         body {
             font-family: 'Nunito', sans-serif;

--- a/resources/views/partials/_post_card.blade.php
+++ b/resources/views/partials/_post_card.blade.php
@@ -1,0 +1,35 @@
+<a href="{{ route('post.show', ['post' => $post['id']]) }}" class="block w-64">
+    <div class="col-span-1 rounded-lg p-4 shadow-lg hover:shadow-md">
+        <p class="font-bold text-lg mb-2">
+            {{ htmlspecialchars($post['title']) }}
+        </p>
+        <div class="flex justify-between items-end">
+            <p class="flex items-center">
+                <img class="h-5 w-5 rounded-full mr-1" src="{{ $post['user']['profile_image_url'] }}" alt="{{ htmlspecialchars($post['user']['name']) }}">
+                <span class="text-xs text-gray-600">
+                    {{ htmlspecialchars($post['user']['name']) }}
+                </span>
+            </p>
+
+            @auth
+                @if($post['user']['id'] === Auth::user()->id)
+                <form class="relative"
+                    action="{{ route('post.destroy', ['post' => $post['id']]) }}"
+                    method="POST">
+                    @csrf
+                    @method('DELETE')
+
+                    <button
+                        aria-label="記事を削除する"
+                        class="before:absolute before:-right-1/2 before:-top-12 before:text-sm before:hidden before:rounded-lg before:shadow-lg before:content-['削除'] before:text-white before:whitespace-nowrap before:p-2 before:bg-black before:opacity-60 hover:before:inline-block"
+                        type="submit"
+                    >
+                        <img class="h-6 w-6" src="/img/trash.png">
+                    </button>
+                </form>
+                @endif
+            @endauth
+
+        </div>
+    </div>
+</a>

--- a/resources/views/post/index.blade.php
+++ b/resources/views/post/index.blade.php
@@ -39,6 +39,27 @@
                     </form>
                 </div>
             </section>
+
+            <hr class="mb-6">
+
+            <section class="mb-20">
+                <h1 class="mb-8 text-lg">記事一覧</h1>
+                <div class="flex justify-around flex-wrap flex-grow gap-8">
+
+                    @if(count($posts) === 0)
+
+                    <div class="text-center">
+                        <p>まだ記事がないようです…🤔</p>
+                        <p>上のフォームから何か書いてみましょう</p>
+                    </div>
+
+                    @else
+
+                    @each('partials._post_card', $posts, 'post')
+
+                    @endif
+                </div>
+            </section>
         </div>
     </div>
 @endsection

--- a/resources/views/post/show.blade.php
+++ b/resources/views/post/show.blade.php
@@ -1,0 +1,72 @@
+@extends('partials._layout')
+
+@section('content')
+    <div class="mt-10 mx-8">
+        <div class="max-w-5xl mx-auto">
+            <div class="mb-6">
+                <a href="/" class="hover:underline text-teal-800">
+                    &lt; 記事一覧画面に戻る
+                </a>
+            </div>
+
+            <h1 class="font-bold text-3xl mb-4">
+                {{ $post['title'] }}
+            </h1>
+
+            <div class="flex justify-between items-end">
+                <div>
+                    <p class="flex items-center mb-1">
+                        <img class="h-5 w-5 rounded-full mr-1"
+                            src="{{ $post['user']['profile_image_url'] }}"
+                            alt="{{ $post['user']['name'] }}">
+                        <span class="text-gray-600 text-sm">
+                            {{ $post['user']['name'] }}
+                        </span>
+                    </p>
+                    <p class="text-sm">
+                        <span>作成日時: </span>
+                        <span>{{ $post['created_at'] }}</span>
+                    </p>
+                </div>
+
+                @auth
+                    @if($post['user']['id'] === Auth::user()->id)
+                        <div class="flex items-start gap-4">
+                            <form
+                                class="relative"
+                                action="{{ route('post.destroy', ['post' => $post['id']]) }}"
+                            >
+                                @csrf
+                                @method('DELETE')
+
+                                <button
+                                    aria-label="削除する"
+                                    class="before:absolute before:-right-0.5 before:-top-12 before:text-sm before:hidden before:rounded-lg before:shadow-lg before:content-['削除'] before:text-white before:whitespace-nowrap before:p-2 before:bg-black before:opacity-60 hover:before:inline-block"
+                                    type="submit"
+                                >
+                                    <img class="h-10 w-10" src="/img/trash.png">
+                                </button>
+                            </form>
+
+                            <span class="relative">
+                                <a
+                                    aria-label="編集する"
+                                    class="before:absolute before:-right-0.5 before:-top-12 before:text-sm before:hidden before:rounded-lg before:shadow-lg before:content-['編集'] before:text-white before:whitespace-nowrap before:p-2 before:bg-black before:opacity-60 hover:before:inline-block"
+                                    href="#"
+                                >
+                                    <img class="h-10 w-10" src="/img/edit.png">
+                                </a>
+                            </span>
+                        </div>
+                    @endif
+                @endauth
+            </div>
+
+            <hr class="mt-4 pb-10">
+
+            <p>
+                {{ nl2br(htmlspecialchars($post['content'])) }}
+            </p>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', fn () => view('root'));
+Route::get('/', [PostController::class, 'index']);
 
 Route::get('/signup', [UserController::class, 'create']);
 Route::resource('/user', UserController::class)->only([
@@ -30,5 +30,7 @@ Route::resource('/session', SessionController::class)->only([
 ]);
 
 Route::resource('/post', PostController::class)->only([
+    'show',
     'store',
+    'destroy',
 ]);


### PR DESCRIPTION
一旦続けてブランチを切ったので、差分が分かるよう base を feat/create-post にむけています。

## 内容
- [x] 記事の一覧・詳細取得のバックエンド実装
- [x] 記事の一覧・詳細取得の view 実装

## 備考
- Service は、ファイルが多くなりすぎるので、ディレクトリを分けるなどして後から調整しようと思います。
- Eloquent の要領がまだ掴めていなくて、eager load と where の組み合わせ方がよく分からず、全件取得した後で collection から find するようなコードを書いています。`Post::with('user')->where('iid', $id)->get();` みたいに書けるかと思って探してたんですが見つからなかったです。