### PR TITLE
必要なエラーのフィードバック

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -11,7 +11,9 @@ use App\Services\IndexTagServiceInterface;
 use App\Services\ShowPostServiceInterface;
 use App\Services\StorePostServiceInterface;
 use App\Services\UpdatePostServiceInterface;
+use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Validation\UnauthorizedException;
 
@@ -45,36 +47,67 @@ class PostController extends Controller
         StorePostRequest $request,
         StorePostServiceInterface $store_post_service,
     ) {
-        $form_data = $request->validated();
+        try {
+            // ゲストユーザーのエラー処理
+            if ($request->user() === null) {
+                return redirect('/')->with([
+                'message' => 'ゲストユーザーは記事を投稿できません。新規会員登録またはログインしてください',
+            ]);
+            }
 
-        $store_post_service->execute(
-            user_id: $request->user()->id,
-            title: $form_data['title'],
-            content: $form_data['content'],
-            thumbnail_image_index: $form_data['thumbnail_image_index'],
-            images: $request->file('images'),
-            tag_ids: isset($form_data['tags']) ? $form_data['tags'] : null,
-        );
+            $form_data = $request->validated();
 
-        return redirect('/');
+            $store_post_service->execute(
+                user_id: $request->user()->id,
+                title: $form_data['title'],
+                content: $form_data['content'],
+                thumbnail_image_index: $form_data['thumbnail_image_index'],
+                images: $request->file('images'),
+                tag_ids: isset($form_data['tags']) ? $form_data['tags'] : null,
+            );
+
+            return redirect('/');
+        } catch (Exception $e) {
+            return redirect('/')->with([
+                'message' => '記事の作成に失敗しました',
+            ]);
+        }
     }
 
 
     public function edit(
+        Request $request,
         ShowPostServiceInterface $show_post_service,
         IndexTagServiceInterface $index_tag_service,
         string $post_id,
     ) {
-        $post = $show_post_service->execute($post_id);
-        $all_tags = $index_tag_service->execute();
+        try {
+            // ゲストユーザーのエラー処理
+            // 記事の取得処理が省略可能なため、他のユーザーの場合と分けて先に行なっている
+            if ($request->user() === null) {
+                throw new UnauthorizedException();
+            }
 
-        $related_tag_ids = $post->tags()->getResults()->pluck('id')->toArray();
+            $post = $show_post_service->execute($post_id);
 
-        return view('post.edit', [
-            'post' => $post,
-            'tags' => $all_tags,
-            'tag_ids' => $related_tag_ids,
-        ]);
+            // 他のユーザーのエラー処理
+            if ($post->user->id !== $request->user()->id) {
+                throw new UnauthorizedException();
+            }
+
+            $all_tags = $index_tag_service->execute();
+            $related_tag_ids = $post->tags()->getResults()->pluck('id')->toArray();
+
+            return view('post.edit', [
+                'post' => $post,
+                'tags' => $all_tags,
+                'tag_ids' => $related_tag_ids,
+            ]);
+        } catch (UnauthorizedException $e) {
+            return redirect('/')->with([
+                'message' => '他のユーザーの記事を編集することはできません',
+            ]);
+        }
     }
 
     public function update(
@@ -82,19 +115,25 @@ class PostController extends Controller
         UpdatePostServiceInterface $update_post_service,
         string $post_id,
     ) {
-        $form_data = $request->validated();
+        try {
+            $form_data = $request->validated();
 
-        $update_post_service->execute(
-            post_id: $post_id,
-            user_id: $request->user()->id,
-            title: $form_data['title'],
-            content: $form_data['content'],
-            thumbnail_image_index: $form_data['thumbnail_image_index'],
-            images: $request->file('images'),
-            tag_ids: isset($form_data['tags']) ? $form_data['tags'] : null,
-        );
+            $update_post_service->execute(
+                post_id: $post_id,
+                user_id: $request->user()->id,
+                title: $form_data['title'],
+                content: $form_data['content'],
+                thumbnail_image_index: $form_data['thumbnail_image_index'],
+                images: $request->file('images'),
+                tag_ids: isset($form_data['tags']) ? $form_data['tags'] : null,
+            );
 
-        return redirect(route('post.show', ['post' => $post_id]));
+            return redirect(route('post.show', ['post' => $post_id]));
+        } catch (Exception $e) {
+            return redirect(route('post.show', ['post' => $post_id]))->with([
+                'message' => '更新処理に失敗しました',
+            ]);
+        }
     }
 
     public function destroy(

--- a/app/Http/Requests/StorePostRequest.php
+++ b/app/Http/Requests/StorePostRequest.php
@@ -7,16 +7,6 @@ use Illuminate\Foundation\Http\FormRequest;
 class StorePostRequest extends FormRequest
 {
     /**
-     * Determine if the user is authorized to make this request.
-     *
-     * @return bool
-     */
-    public function authorize()
-    {
-        return $this->user() !== null;
-    }
-
-    /**
      * Get the validation rules that apply to the request.
      *
      * @return array<string, mixed>

--- a/app/Services/StorePostService.php
+++ b/app/Services/StorePostService.php
@@ -46,7 +46,7 @@ class StorePostService implements StorePostServiceInterface
         } catch (Throwable $e) {
             DB::rollBack();
 
-            throw $e;
+            throw new Exception(previous: $e);
         }
     }
 

--- a/app/Services/UpdatePostService.php
+++ b/app/Services/UpdatePostService.php
@@ -51,7 +51,7 @@ class UpdatePostService implements UpdatePostServiceInterface
         } catch (Throwable $e) {
             DB::rollBack();
 
-            throw $e;
+            throw new Exception(previous: $e);
         }
     }
 

--- a/resources/views/partials/_layout.blade.php
+++ b/resources/views/partials/_layout.blade.php
@@ -17,6 +17,8 @@
 <body>
     @include('partials._header')
 
+    @include('partials._message')
+
     <main>
         @yield('content')
     </main>

--- a/resources/views/partials/_message.blade.php
+++ b/resources/views/partials/_message.blade.php
@@ -1,0 +1,5 @@
+@if(session('message') !== null)
+    <div class="mx-4 mt-12">
+        <p class="p-2 rounded-lg bg-red-200 text-sm text-center max-w-2xl mx-auto">{{ session('message') }}</p>
+    </div>
+@endif

--- a/resources/views/post/show.blade.php
+++ b/resources/views/post/show.blade.php
@@ -45,6 +45,7 @@
                             <form
                                 class="relative"
                                 action="{{ route('post.destroy', ['post' => $post['id']]) }}"
+                                method="POST"
                             >
                                 @csrf
                                 @method('DELETE')


### PR DESCRIPTION
## 内容
- 記事の作成について、FormRequest レベルの authorization を削除 - [rm request level authorization on storing post](https://github.com/you-5805/kenshu-backend-laravel/commit/da535048941d9b297fd10cc6622571c03df4d225)
- ブラウザ上から起こることが想定されるようなエラーについて、エラーメッセージを返す - [impl: error feedback](https://github.com/you-5805/kenshu-backend-laravel/commit/76a1dc9e97774bd074e8b2ee96234ba1c00f7930)
- エラーメッセージを表示するビューの実装 - [impl: error feedback view](https://github.com/you-5805/kenshu-backend-laravel/commit/a022810495e21bcd0fe8d505cc389982eecefbef)

## 備考
生 PHP での実装時と同様に、ブラウザから誤って起こることが基本的に想定できない不正なリクエスト (他人の記事の更新、削除) については、FormRequest レベルで弾いているので、401 を返却して UI 上でのその他のフィードバックはありません。